### PR TITLE
Adds ** to fix keyword parameter deprecation

### DIFF
--- a/lib/active_admin_paranoia/dsl.rb
+++ b/lib/active_admin_paranoia/dsl.rb
@@ -9,7 +9,7 @@ module ActiveAdminParanoia
         options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_archived', count: ids.count, model: resource_class.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
-          controller.redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
+          controller.redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(**options))
         else
           controller.redirect_to :back, options
         end
@@ -40,7 +40,7 @@ module ActiveAdminParanoia
         options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: ids.count, model: resource_class.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
-          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
+          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(**options))
         else
           redirect_to :back, options
         end
@@ -63,7 +63,7 @@ module ActiveAdminParanoia
         options = { notice: I18n.t('active_admin_paranoia.batch_actions.succesfully_restored', count: 1, model: resource_class.model_name, plural_model: resource_class.to_s.downcase.pluralize) }
         # For more info, see here: https://github.com/rails/rails/pull/22506
         if Rails::VERSION::MAJOR >= 5
-          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(options))
+          redirect_back({ fallback_location: ActiveAdmin.application.root_to }.merge(**options))
         else
           redirect_to :back, options
         end
@@ -81,7 +81,7 @@ module ActiveAdmin
       class IndexTableFor < ::ActiveAdmin::Views::TableFor
         alias_method :orig_defaults, :defaults
 
-        def defaults(resource, options = {})
+        def defaults(resource, **options)
           if resource.respond_to?(:deleted?) && resource.deleted?
             if controller.action_methods.include?('restore') && authorized?(ActiveAdminParanoia::Auth::RESTORE, resource)
               # TODO: find a way to use the correct path helper


### PR DESCRIPTION
This PR fixes the following deprecation:
```
/ruby/2.7.7/lib/ruby/gems/2.7.0/bundler/gems/active_admin_paranoia-0bfc4a5f0dbd/lib/active_admin_paranoia/dsl.rb:66: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

I've only seen a deprecation happen currently on line 66, but I changed a few other places in this file as I suspect they could cause the same deprecation.